### PR TITLE
Properly shift the value accumulator for LE when pushing.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@ impl Endianness for LittleEndian {
                value_acc: &mut N,
                bits: u32,
                mut value: N) where N: Numeric {
-        value <<= *bits_acc;
+        *value_acc <<= *bits_acc;
         *value_acc |= value;
         *bits_acc += bits;
     }


### PR DESCRIPTION
This was causing a bug where the value was being shifted itself, and then pushed on top of the existing value, but only for LittleEndian; BigEndian was properly implemented.