### PR TITLE
[WIP] Fix addition of zero values during pushes and logic error.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,9 +190,7 @@ impl Endianness for BigEndian {
                value_acc: &mut N,
                bits: u32,
                value: N) where N: Numeric {
-        if !value_acc.is_zero() {
-            *value_acc <<= bits;
-        }
+        *value_acc <<= bits;
         *value_acc |= value;
         *bits_acc += bits;
     }
@@ -255,10 +253,8 @@ impl Endianness for LittleEndian {
     fn push<N>(bits_acc: &mut u32,
                value_acc: &mut N,
                bits: u32,
-               mut value: N) where N: Numeric {
-        if !value.is_zero() {
-            value <<= *bits_acc;
-        }
+               value: N) where N: Numeric {
+        *value_acc <<= bits;
         *value_acc |= value;
         *bits_acc += bits;
     }


### PR DESCRIPTION
This was otherwise a bug where reading large values, with constituent bits spanning multiple bytes, could lead to a situation where partial reads resulted in a zero value for that read alone, which otherwise would properly shift the accumulated value to generate the correct result, but were getting silently dumped on the floor.

For example:

Bitstream, little-endian ordering: [(00000001)] [000000(00)]

Each set of values in brackets is a single byte, and the target value we want to extract is in the parentheses, spanning 10 bits across two bytes.  With the previous code, if we read the remaining two bits, we'd get a zero value, giving us an accumulated value of one, when the real value is actually four.

As well, the push method for LittleEndian was improperly shifting the value, instead of the accumulator, with the accumulated bits instead of the bits for the given value.

The biggest issue here is that the unit tests are all out of whack after this change.  I've yet to tackle them because I wanted to run this by you first.  For me, this was a legitimate bug, but maybe for your use case, it's not?

Any deep thoughts here?  I've gone back and forth on whether or not I should just copypasta the bits I need into my project and be done with it, but figured I'd see if you thought it made sense to forge ahead getting these things upstream.