### PR TITLE
Fix calculation of max integer value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,7 +475,7 @@ impl<E: Endianness, N: Numeric> BitQueue<E, N> {
     #[inline]
     pub fn from_value(value: N, bits: u32) -> BitQueue<E, N> {
         assert!(if bits < N::bits_size() {
-            value < (N::one() << bits)
+            value <= !(N::one() << (N::bits_size() - 1)) >> (N::bits_size() - bits - 1)
         } else {
             bits <= N::bits_size()
         });

--- a/src/write.rs
+++ b/src/write.rs
@@ -367,7 +367,7 @@ impl<W: io::Write, E: Endianness> BitWriter<W, E> {
             32 => self
                 .write(value, 0xFFFF_FFFFu32)
                 .and_then(|()| self.write_bit(false)),
-            bits @ 32..=63 => self
+            bits @ 33..=63 => self
                 .write(value, (1u64 << bits) - 1)
                 .and_then(|()| self.write_bit(false)),
             64 => self

--- a/src/write.rs
+++ b/src/write.rs
@@ -212,10 +212,11 @@ impl<W: io::Write, E: Endianness> BitWriter<W, E> {
                 io::ErrorKind::InvalidInput,
                 "excessive bits for type written",
             ))
-        } else if (bits < U::bits_size()) && (value >= (U::one() << bits)) {
+        } else if (bits < U::bits_size()) && (value > (!(U::one() << (U::bits_size() - 1)) >> (U::bits_size() - bits - 1))) {
             Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "excessive value for bits written",
+                format!("Value {:?} is greater then max value for {:?} bits: {:?}",
+                    value, bits, !(U::one() << (U::bits_size() - 1)) >> (U::bits_size() - bits - 1))
             ))
         } else if bits < self.bitqueue.remaining_len() {
             self.bitqueue.push(bits, value.to_u8());

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -587,7 +587,8 @@ fn test_writer_io_errors_be() {
     );
 
     /*signed values*/
-    let mut w = BitWriter::endian(LimitedWriter::new(1), BigEndian);
+    let mut w = BitWriter::endian(LimitedWriter::new(2), BigEndian);
+    assert!(w.write_signed(8, -40i8).is_ok());
     assert!(w.write_signed(2, -2).is_ok());
     assert!(w.write_signed(3, -2).is_ok());
     assert!(w.write_signed(5, 7).is_ok());
@@ -677,7 +678,8 @@ fn test_writer_io_errors_le() {
     );
 
     /*signed values*/
-    let mut w = BitWriter::endian(LimitedWriter::new(1), LittleEndian);
+    let mut w = BitWriter::endian(LimitedWriter::new(3), LittleEndian);
+    assert!(w.write_signed(16, 10i16).is_ok());
     assert!(w.write_signed(2, 1).is_ok());
     assert!(w.write_signed(3, -4).is_ok());
     assert!(w.write_signed(5, 13).is_ok());


### PR DESCRIPTION
This fixes #3 as explained in comment and adds more meaningful error message. Also fixes warning about overlapping matches. Before merging let me add tests for this case
EDIT: tests added