### PR TITLE
derive Clone on BitQueue, BitReader

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,7 +574,7 @@ impl Endianness for LittleEndian {
 
 /// A queue for efficiently pushing bits onto a value
 /// and popping them off a value.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct BitQueue<E: Endianness, N: Numeric> {
     phantom: PhantomData<E>,
     value: N,

--- a/src/read.rs
+++ b/src/read.rs
@@ -201,6 +201,7 @@ pub trait HuffmanRead<E: Endianness> {
 /// This will read exactly as many whole bytes needed to return
 /// the requested number of bits.  It may cache up to a single partial byte
 /// but no more.
+#[derive(Clone)]
 pub struct BitReader<R: io::Read, E: Endianness> {
     reader: R,
     bitqueue: BitQueue<E, u8>,


### PR DESCRIPTION
This is useful for querying the position within a H.264 bitstream
relative to the final one bit; details in dholroyd/h264-reader#28.

The default #![derive(Clone)] behavior is nice: BitReader will be
Clone iff the backing std::io::Read is also Clone. Out of paranoia,
I added a test that clone works properly and that it's still possible
to instantiate a BitReader with a non-Clone R.