### PR TITLE
Don't box trait objects returned from `writer_ref()` and `reader_ref()`

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -1021,7 +1021,7 @@ pub trait ByteRead {
     }
 
     /// Returns mutable reference to underlying reader
-    fn reader_ref(&mut self) -> Box<&mut dyn io::Read>;
+    fn reader_ref(&mut self) -> &mut dyn io::Read;
 }
 
 /// For reading aligned bytes from a stream of bytes in a given endianness.
@@ -1096,8 +1096,8 @@ impl<R: io::Read, E: Endianness> ByteRead for ByteReader<R, E> {
     }
 
     #[inline]
-    fn reader_ref(&mut self) -> Box<&mut dyn io::Read> {
-        Box::new(&mut self.reader)
+    fn reader_ref(&mut self) -> &mut dyn io::Read {
+        &mut self.reader
     }
 }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -1232,7 +1232,7 @@ pub trait ByteWrite {
     }
 
     /// Returns mutable reference to underlying writer
-    fn writer_ref(&mut self) -> Box<&mut dyn io::Write>;
+    fn writer_ref(&mut self) -> &mut dyn io::Write;
 }
 
 impl<W: io::Write, E: Endianness> ByteWrite for ByteWriter<W, E> {
@@ -1247,8 +1247,8 @@ impl<W: io::Write, E: Endianness> ByteWrite for ByteWriter<W, E> {
     }
 
     #[inline]
-    fn writer_ref(&mut self) -> Box<&mut dyn io::Write> {
-        Box::new(&mut self.writer)
+    fn writer_ref(&mut self) -> &mut dyn io::Write {
+        &mut self.writer
     }
 }
 


### PR DESCRIPTION
That's otherwise one unnecessary heap allocation per access.