### PR TITLE
{To,From}{Bit,Byte}StreamWith: allow lifetime-constrained Contexts

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -463,7 +463,7 @@ pub trait BitWrite {
     }
 
     /// Builds and writes complex type with context
-    fn build_with<T: ToBitStreamWith>(
+    fn build_with<'a, T: ToBitStreamWith<'a>>(
         &mut self,
         build: &T,
         context: &T::Context,
@@ -1223,7 +1223,7 @@ pub trait ByteWrite {
     }
 
     /// Builds and writes complex type with context
-    fn build_with<T: ToByteStreamWith>(
+    fn build_with<'a, T: ToByteStreamWith<'a>>(
         &mut self,
         build: &T,
         context: &T::Context,
@@ -1294,9 +1294,9 @@ pub trait ToBitStream {
 
 /// Implemented by complex types that require additional context
 /// to build themselves to a writer
-pub trait ToBitStreamWith {
+pub trait ToBitStreamWith<'a> {
     /// Some context to use when writing
-    type Context;
+    type Context: 'a;
 
     /// Error generated during building, such as `io::Error`
     type Error;
@@ -1325,9 +1325,9 @@ pub trait ToByteStream {
 
 /// Implemented by complex types that require additional context
 /// to build themselves to a writer
-pub trait ToByteStreamWith {
+pub trait ToByteStreamWith<'a> {
     /// Some context to use when writing
-    type Context;
+    type Context: 'a;
 
     /// Error generated during building, such as `io::Error`
     type Error;


### PR DESCRIPTION
**Warning:** this proposal introduces a breaking change. The change is as trivial as adding `<'_>`, but all implementers of `{To,From}{Bit,Byte}StreamWith` would be affected. IMO this would warrant a major version bump.

See the examples for a complete use case.

In current implementation, `{To,From}{Bit,Byte}StreamWith` impose that the `Context` be static. In some cases, we want to pass a `Context` which owns a reference to another struct.

This MR adds a lifetime to these traits to allow using a `Context` constrained by a lifetime. Ex.:

```rust
impl FromBitStreamWith<'a> for FrameHeader {
    type Context = StreamInfo<'a>;
    [...]
}
```

Implementations for which the `Context` is `'static` bound can use:

```rust
impl FromBitStreamWith<'_> for FrameHeader {
    type Context = StreamInfo;
    [...]
}
```