### PR TITLE
Derive `Debug` for some types so they can be used in `Debug` derived `struct`s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,7 @@ pub trait Endianness: Sized {
 }
 
 /// Big-endian, or most significant bits first
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct BigEndian;
 
 /// Big-endian, or most significant bits first
@@ -523,7 +523,7 @@ impl Endianness for BigEndian {
 }
 
 /// Little-endian, or least significant bits first
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct LittleEndian;
 
 /// Little-endian, or least significant bits first
@@ -673,7 +673,7 @@ impl Endianness for LittleEndian {
 
 /// A queue for efficiently pushing bits onto a value
 /// and popping them off a value.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct BitQueue<E: Endianness, N: Numeric> {
     phantom: PhantomData<E>,
     value: N,

--- a/src/read.rs
+++ b/src/read.rs
@@ -348,7 +348,7 @@ pub trait HuffmanRead<E: Endianness> {
 /// This will read exactly as many whole bytes needed to return
 /// the requested number of bits.  It may cache up to a single partial byte
 /// but no more.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BitReader<R: io::Read, E: Endianness> {
     reader: R,
     bitqueue: BitQueue<E, u8>,
@@ -1033,6 +1033,7 @@ pub trait ByteRead {
 /// For reading aligned bytes from a stream of bytes in a given endianness.
 ///
 /// This only reads aligned values and maintains no internal state.
+#[derive(Debug)]
 pub struct ByteReader<R: io::Read, E: Endianness> {
     phantom: PhantomData<E>,
     reader: R,


### PR DESCRIPTION
Required for:

```rust
 #[derive(Debug)]
 pub struct AccessUnitIter<'a> {
     headers_r: Option<BitReader<Cursor<&'a [u8]>, BigEndian>>,
     [...]
 }
```

**Note:** first commit introduces a `.gitignore` file so as to avoid accidentally adding `Cargo.lock` or the `target` directory.