### PR TITLE
Add default impls for BitRead::read_signed_in() and BitWrite::write_s…

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -248,7 +248,10 @@ pub trait BitRead {
     /// is larger than the output type.
     fn read_signed_in<const BITS: u32, S>(&mut self) -> io::Result<S>
     where
-        S: SignedNumeric;
+        S: SignedNumeric,
+    {
+        self.read_signed(BITS)
+    }
 
     /// Reads whole value from the stream whose size in bits is equal
     /// to its type's size.

--- a/src/write.rs
+++ b/src/write.rs
@@ -372,7 +372,10 @@ pub trait BitWrite {
     /// is larger than the output type.
     fn write_signed_out<const BITS: u32, S>(&mut self, value: S) -> io::Result<()>
     where
-        S: SignedNumeric;
+        S: SignedNumeric,
+    {
+        self.write_signed(BITS, value)
+    }
 
     /// Writes whole value to the stream whose size in bits
     /// is equal to its type's size.


### PR DESCRIPTION
…igned_out()

This makes their addition backwards compatible.