### PR TITLE
Fix `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/bitstream-io/"
 homepage = "https://github.com/tuffy/bitstream-io"
 repository = "https://github.com/tuffy/bitstream-io"
 edition = "2018"
-rust-version = "1.79"
+rust-version = "1.83"
 
 [dependencies]
 core2 = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,8 @@ edition = "2018"
 rust-version = "1.79"
 
 [dependencies]
-core2 = {version = "0.4", optional = true, default-features = false, features = ["alloc"]}
+core2 = "0.4"
 
 [features]
 std = []
 default = ["std"]
-alloc = ["core2"]

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -11,29 +11,10 @@
 
 #![warn(missing_docs)]
 
-use super::BitQueue;
-use super::Endianness;
-#[cfg(feature = "alloc")]
-use alloc::boxed::Box;
-#[cfg(feature = "alloc")]
-use alloc::collections::BTreeMap;
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
-#[cfg(feature = "alloc")]
-use core::fmt;
-#[cfg(feature = "alloc")]
-use core::marker::PhantomData;
-#[cfg(feature = "alloc")]
-use core2::error::Error;
+use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
+use core::{error::Error, fmt, marker::PhantomData};
 
-#[cfg(not(feature = "alloc"))]
-use std::collections::BTreeMap;
-#[cfg(not(feature = "alloc"))]
-use std::error::Error;
-#[cfg(not(feature = "alloc"))]
-use std::fmt;
-#[cfg(not(feature = "alloc"))]
-use std::marker::PhantomData;
+use super::{BitQueue, Endianness};
 
 /// A compiled Huffman tree element for use with the `read_huffman` method.
 /// Returned by `compile_read_tree`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,17 +93,18 @@
 
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
-#![cfg_attr(feature = "alloc", no_std)]
+#![no_std]
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
-use core::fmt::Debug;
-use core::marker::PhantomData;
-use core::mem;
-use core::ops::{BitOrAssign, BitXor, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub};
-#[cfg(feature = "alloc")]
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(not(feature = "std"))]
 use core2::io;
-#[cfg(not(feature = "alloc"))]
+
+use core::ops::{BitOrAssign, BitXor, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub};
+use core::{fmt::Debug, marker::PhantomData, mem};
+#[cfg(feature = "std")]
 use std::io;
 
 pub mod huffman;

--- a/src/read.rs
+++ b/src/read.rs
@@ -171,13 +171,11 @@
 
 #![warn(missing_docs)]
 
-#[cfg(feature = "alloc")]
-use alloc::vec;
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
-#[cfg(feature = "alloc")]
+#[cfg(not(feature = "std"))]
 use core2::io::{self, SeekFrom};
-#[cfg(not(feature = "alloc"))]
+
+use alloc::{vec, vec::Vec};
+#[cfg(feature = "std")]
 use std::io::{self, SeekFrom};
 
 use super::{

--- a/tests/huffman.rs
+++ b/tests/huffman.rs
@@ -1,5 +1,12 @@
+extern crate alloc;
 extern crate bitstream_io;
+
 use bitstream_io::huffman::{compile_read_tree, compile_write_tree, HuffmanTreeError};
+#[cfg(not(feature = "std"))]
+use core2::io;
+
+#[cfg(feature = "std")]
+use std::io;
 
 #[test]
 fn test_huffman_errors() {
@@ -63,9 +70,10 @@ fn test_huffman_errors() {
 fn test_huffman_values() {
     use bitstream_io::huffman::compile_read_tree;
     use bitstream_io::{BigEndian, BitReader, HuffmanRead};
-    use std::io::Cursor;
-    use std::ops::Deref;
-    use std::rc::Rc;
+    use io::Cursor;
+
+    use alloc::rc::Rc;
+    use core::ops::Deref;
 
     let data = [0xB1, 0xED];
 
@@ -105,7 +113,7 @@ fn test_huffman_values() {
 fn test_lengthy_huffman_values() {
     use bitstream_io::huffman::{compile_read_tree, compile_write_tree};
     use bitstream_io::{BitReader, BitWrite, BitWriter, HuffmanRead, HuffmanWrite, BE, LE};
-    use std::io::Cursor;
+    use io::Cursor;
 
     let max_bits = 70;
     let mut spec = Vec::new();

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -7,7 +7,12 @@
 // except according to those terms.
 
 extern crate bitstream_io;
-use std::io::Cursor;
+
+#[cfg(not(feature = "std"))]
+use core2::io::{self, Cursor};
+
+#[cfg(feature = "std")]
+use std::io::{self, Cursor};
 
 #[test]
 fn test_read_queue_be() {
@@ -514,7 +519,7 @@ fn test_reader_huffman_le() {
 #[test]
 fn test_reader_io_errors_be() {
     use bitstream_io::{BigEndian, BitRead, BitReader};
-    use std::io::ErrorKind;
+    use io::ErrorKind;
 
     let actual_data: [u8; 1] = [0xB1];
 
@@ -595,7 +600,7 @@ fn test_reader_io_errors_be() {
 #[test]
 fn test_reader_io_errors_le() {
     use bitstream_io::{BitRead, BitReader, LittleEndian};
-    use std::io::ErrorKind;
+    use io::ErrorKind;
 
     let actual_data: [u8; 1] = [0xB1];
 
@@ -676,7 +681,7 @@ fn test_reader_io_errors_le() {
 #[test]
 fn test_reader_bits_errors() {
     use bitstream_io::{BigEndian, BitRead, BitReader, LittleEndian};
-    use std::io::ErrorKind;
+    use io::ErrorKind;
     let actual_data = [0u8; 10];
 
     let mut r = BitReader::endian(Cursor::new(&actual_data), BigEndian);
@@ -766,8 +771,8 @@ fn test_clone() {
     // Can still instantiate a BitReader when the backing std::io::Read is
     // !Clone.
     struct NotCloneRead<'a>(&'a [u8]);
-    impl<'a> std::io::Read for NotCloneRead<'a> {
-        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+    impl<'a> io::Read for NotCloneRead<'a> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
             self.0.read(buf)
         }
     }

--- a/tests/read_seek.rs
+++ b/tests/read_seek.rs
@@ -1,7 +1,9 @@
-use std::io;
-use std::io::{Cursor, SeekFrom};
-
 use bitstream_io::{BigEndian, BitRead, BitReader, Endianness, LittleEndian};
+#[cfg(not(feature = "std"))]
+use core2::io::{self, Cursor, SeekFrom};
+
+#[cfg(feature = "std")]
+use std::io::{self, Cursor, SeekFrom};
 
 #[test]
 fn test_reader_pos_be() -> io::Result<()> {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -7,7 +7,12 @@
 // except according to those terms.
 
 extern crate bitstream_io;
+
 use bitstream_io::{BigEndian, BitRead, BitReader, BitWrite, BitWriter, LittleEndian};
+#[cfg(not(feature = "std"))]
+use core2::io::Cursor;
+
+#[cfg(feature = "std")]
 use std::io::Cursor;
 
 macro_rules! define_roundtrip {
@@ -141,7 +146,7 @@ fn test_auto_signedness() {
 
     macro_rules! define_roundtrip {
         ($n:ident, $i:ident, $w:ident, $r:ident) => {
-            fn $n<I: Integer + $i + std::ops::AddAssign, E: Endianness>(
+            fn $n<I: Integer + $i + core::ops::AddAssign, E: Endianness>(
                 mut start: I,
                 end: I,
                 bits: u32,

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -9,6 +9,11 @@
 extern crate bitstream_io;
 
 use bitstream_io::{BigEndian, BitWrite, BitWriter};
+#[cfg(not(feature = "std"))]
+use core2::io;
+
+#[cfg(feature = "std")]
+use std::io;
 
 #[test]
 fn test_write_queue_be() {
@@ -366,82 +371,82 @@ fn test_writer_edge_cases_be() {
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, BigEndian)
-            .write_signed(8, std::i8::MAX)
+            .write_signed(8, core::i8::MAX)
             .unwrap();
     }
-    assert_eq!(bytes, std::i8::MAX.to_be_bytes());
+    assert_eq!(bytes, core::i8::MAX.to_be_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, BigEndian)
-            .write_signed(8, std::i8::MIN)
+            .write_signed(8, core::i8::MIN)
             .unwrap();
     }
-    assert_eq!(bytes, std::i8::MIN.to_be_bytes());
+    assert_eq!(bytes, core::i8::MIN.to_be_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, BigEndian)
-            .write_signed(16, std::i16::MAX)
+            .write_signed(16, core::i16::MAX)
             .unwrap();
     }
-    assert_eq!(bytes, std::i16::MAX.to_be_bytes());
+    assert_eq!(bytes, core::i16::MAX.to_be_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, BigEndian)
-            .write_signed(16, std::i16::MIN)
+            .write_signed(16, core::i16::MIN)
             .unwrap();
     }
-    assert_eq!(bytes, std::i16::MIN.to_be_bytes());
+    assert_eq!(bytes, core::i16::MIN.to_be_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, BigEndian)
-            .write_signed(32, std::i32::MAX)
+            .write_signed(32, core::i32::MAX)
             .unwrap();
     }
-    assert_eq!(bytes, std::i32::MAX.to_be_bytes());
+    assert_eq!(bytes, core::i32::MAX.to_be_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, BigEndian)
-            .write_signed(32, std::i32::MIN)
+            .write_signed(32, core::i32::MIN)
             .unwrap();
     }
-    assert_eq!(bytes, std::i32::MIN.to_be_bytes());
+    assert_eq!(bytes, core::i32::MIN.to_be_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, BigEndian)
-            .write_signed(64, std::i64::MAX)
+            .write_signed(64, core::i64::MAX)
             .unwrap();
     }
-    assert_eq!(bytes, std::i64::MAX.to_be_bytes());
+    assert_eq!(bytes, core::i64::MAX.to_be_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, BigEndian)
-            .write_signed(64, std::i64::MIN)
+            .write_signed(64, core::i64::MIN)
             .unwrap();
     }
-    assert_eq!(bytes, std::i64::MIN.to_be_bytes());
+    assert_eq!(bytes, core::i64::MIN.to_be_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, BigEndian)
-            .write_signed(128, std::i128::MAX)
+            .write_signed(128, core::i128::MAX)
             .unwrap();
     }
-    assert_eq!(bytes, std::i128::MAX.to_be_bytes());
+    assert_eq!(bytes, core::i128::MAX.to_be_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, BigEndian)
-            .write_signed(128, std::i128::MIN)
+            .write_signed(128, core::i128::MIN)
             .unwrap();
     }
-    assert_eq!(bytes, std::i128::MIN.to_be_bytes());
+    assert_eq!(bytes, core::i128::MIN.to_be_bytes());
 }
 
 #[test]
@@ -694,82 +699,82 @@ fn test_writer_edge_cases_le() {
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, LittleEndian)
-            .write_signed(8, std::i8::MAX)
+            .write_signed(8, core::i8::MAX)
             .unwrap();
     }
-    assert_eq!(bytes, std::i8::MAX.to_le_bytes());
+    assert_eq!(bytes, core::i8::MAX.to_le_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, LittleEndian)
-            .write_signed(8, std::i8::MIN)
+            .write_signed(8, core::i8::MIN)
             .unwrap();
     }
-    assert_eq!(bytes, std::i8::MIN.to_le_bytes());
+    assert_eq!(bytes, core::i8::MIN.to_le_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, LittleEndian)
-            .write_signed(16, std::i16::MAX)
+            .write_signed(16, core::i16::MAX)
             .unwrap();
     }
-    assert_eq!(bytes, std::i16::MAX.to_le_bytes());
+    assert_eq!(bytes, core::i16::MAX.to_le_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, LittleEndian)
-            .write_signed(16, std::i16::MIN)
+            .write_signed(16, core::i16::MIN)
             .unwrap();
     }
-    assert_eq!(bytes, std::i16::MIN.to_le_bytes());
+    assert_eq!(bytes, core::i16::MIN.to_le_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, LittleEndian)
-            .write_signed(32, std::i32::MAX)
+            .write_signed(32, core::i32::MAX)
             .unwrap();
     }
-    assert_eq!(bytes, std::i32::MAX.to_le_bytes());
+    assert_eq!(bytes, core::i32::MAX.to_le_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, LittleEndian)
-            .write_signed(32, std::i32::MIN)
+            .write_signed(32, core::i32::MIN)
             .unwrap();
     }
-    assert_eq!(bytes, std::i32::MIN.to_le_bytes());
+    assert_eq!(bytes, core::i32::MIN.to_le_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, LittleEndian)
-            .write_signed(64, std::i64::MAX)
+            .write_signed(64, core::i64::MAX)
             .unwrap();
     }
-    assert_eq!(bytes, std::i64::MAX.to_le_bytes());
+    assert_eq!(bytes, core::i64::MAX.to_le_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, LittleEndian)
-            .write_signed(64, std::i64::MIN)
+            .write_signed(64, core::i64::MIN)
             .unwrap();
     }
-    assert_eq!(bytes, std::i64::MIN.to_le_bytes());
+    assert_eq!(bytes, core::i64::MIN.to_le_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, LittleEndian)
-            .write_signed(128, std::i128::MAX)
+            .write_signed(128, core::i128::MAX)
             .unwrap();
     }
-    assert_eq!(bytes, std::i128::MAX.to_le_bytes());
+    assert_eq!(bytes, core::i128::MAX.to_le_bytes());
 
     let mut bytes = Vec::new();
     {
         BitWriter::endian(&mut bytes, LittleEndian)
-            .write_signed(128, std::i128::MIN)
+            .write_signed(128, core::i128::MIN)
             .unwrap();
     }
-    assert_eq!(bytes, std::i128::MIN.to_le_bytes());
+    assert_eq!(bytes, core::i128::MIN.to_le_bytes());
 }
 
 #[test]
@@ -817,14 +822,14 @@ impl LimitedWriter {
     }
 }
 
-impl std::io::Write for LimitedWriter {
-    fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
+impl io::Write for LimitedWriter {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
         let to_write = buf.len().min(self.can_write);
         self.can_write -= to_write;
         Ok(to_write)
     }
 
-    fn flush(&mut self) -> Result<(), std::io::Error> {
+    fn flush(&mut self) -> Result<(), io::Error> {
         Ok(())
     }
 }
@@ -832,7 +837,7 @@ impl std::io::Write for LimitedWriter {
 #[test]
 fn test_writer_io_errors_be() {
     use bitstream_io::{BigEndian, BitWrite, BitWriter};
-    use std::io::ErrorKind;
+    use io::ErrorKind;
 
     /*individual bits*/
     let mut w = BitWriter::endian(LimitedWriter::new(1), BigEndian);
@@ -928,7 +933,7 @@ fn test_writer_io_errors_be() {
 #[test]
 fn test_writer_io_errors_le() {
     use bitstream_io::{BitWrite, BitWriter, LittleEndian};
-    use std::io::ErrorKind;
+    use io::ErrorKind;
 
     /*individual bits*/
     let mut w = BitWriter::endian(LimitedWriter::new(1), LittleEndian);
@@ -1024,7 +1029,7 @@ fn test_writer_io_errors_le() {
 #[test]
 fn test_writer_bits_errors() {
     use bitstream_io::{BigEndian, BitWrite, BitWriter, LittleEndian};
-    use std::io::{sink, ErrorKind};
+    use io::{sink, ErrorKind};
 
     let mut w = BitWriter::endian(sink(), BigEndian);
     assert_eq!(w.write(9, 0u8).unwrap_err().kind(), ErrorKind::InvalidInput);


### PR DESCRIPTION
Currently `no_std` didn't work properly, as it was only enabled when `alloc` was enabled, meaning that `std` would actually be used if bitstream_io was used with all default features disabled (including `alloc`).

This PR removes the `alloc` feature, as the `alloc` crate is used extensively throughout the codebase, and makes the `std` feature actually toggle whether `std` is used.

Unfortunately I'm not aware of a way to make an optional dependency contingent on a feature being disabled, hence `core2` is no longer optional.

Additionally, this bumps the MSRV because `std::io::ErrorKind::StorageFull` (not my addition) only exists in rust 1.83 onwards.

Please let me know if anything is unclear or needs to be changed.