### PR TITLE
Add CI pipeline.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Rust CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Build & Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        components: clippy
+
+    - name: Install cargo-binstall
+      uses: cargo-bins/cargo-binstall@main
+
+    - name: Run tests
+      run: cargo test
+
+    - name: Run tests (no_std)
+      run: cargo test --no-default-features
+
+    - name: Run clippy
+      run: cargo clippy
+
+    - name: Install cargo-msrv
+      run: cargo binstall --no-confirm cargo-msrv
+
+    - name: Verify MSRV
+      run: cargo msrv verify

--- a/src/read.rs
+++ b/src/read.rs
@@ -172,11 +172,11 @@
 #![warn(missing_docs)]
 
 #[cfg(not(feature = "std"))]
-use core2::io::{self, SeekFrom};
+use core2::io;
 
 use alloc::{vec, vec::Vec};
 #[cfg(feature = "std")]
-use std::io::{self, SeekFrom};
+use std::io;
 
 use super::{
     huffman::ReadHuffmanTree, BitQueue, Endianness, Integer, Numeric, PhantomData, Primitive,
@@ -962,7 +962,7 @@ where
     /// ```
     #[inline]
     pub fn position_in_bits(&mut self) -> io::Result<u64> {
-        let bytes = self.reader.seek(SeekFrom::Current(0))?;
+        let bytes = self.reader.stream_position()?;
         Ok(bytes * 8 - (self.bitqueue.len() as u64))
     }
 }


### PR DESCRIPTION
In my previous PR I noticed that the MSRV was set incorrectly. As such, it's a good idea to add an automatic CI pipeline to prevent that from happening in the future (and to always know that the project builds and passes tests).

The changes to the rust code were made to fix a clippy warning.