### PR TITLE
Add support for no alloc.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,11 @@ jobs:
     - name: Run tests
       run: cargo test
 
-    - name: Run tests (no_std)
-      run: cargo test --no-default-features
+    - name: Check (no_std)
+      run: cargo check --no-default-features
+
+    - name: Check (no_std, alloc)
+      run: cargo check --no-default-features --features alloc
 
     - name: Run clippy
       run: cargo clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,14 @@ repository = "https://github.com/tuffy/bitstream-io"
 edition = "2018"
 rust-version = "1.83"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
-core2 = "0.4"
+core2 = { version = "0.4", default-features = false }
 
 [features]
-std = []
+std = ["core2/std", "alloc"]
+alloc = ["core2/alloc"]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,10 +141,12 @@
 //! of bit reader or bit writer, regardless of the underlying
 //! stream byte source or endianness.
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
 #![no_std]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
@@ -168,8 +170,11 @@ pub use read::{
     BitRead, BitRead2, BitReader, ByteRead, ByteReader, FromBitStream, FromBitStreamUsing,
     FromBitStreamWith, FromByteStream, FromByteStreamUsing, FromByteStreamWith,
 };
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[cfg(feature = "alloc")]
+pub use write::BitRecorder;
 pub use write::{
-    BitRecorder, BitWrite, BitWrite2, BitWriter, BitsWritten, ByteWrite, ByteWriter, ToBitStream,
+    BitWrite, BitWrite2, BitWriter, BitsWritten, ByteWrite, ByteWriter, ToBitStream,
     ToBitStreamUsing, ToBitStreamWith, ToByteStream, ToByteStreamUsing, ToByteStreamWith,
 };
 
@@ -2251,10 +2256,7 @@ impl<const BITS: u32, U: UnsignedInteger> private::Checkable for CheckedUnsigned
 impl<const BITS: u32, U: UnsignedInteger> CheckablePrimitive for CheckedUnsignedFixed<BITS, U> {
     type CountType = FixedBitCount<BITS>;
 
-    fn read<R: BitRead + ?Sized>(
-        reader: &mut R,
-        count: FixedBitCount<BITS>,
-    ) -> std::io::Result<Self> {
+    fn read<R: BitRead + ?Sized>(reader: &mut R, count: FixedBitCount<BITS>) -> io::Result<Self> {
         Ok(Self {
             value: reader.read_unsigned::<BITS, _>()?,
             count,
@@ -2545,7 +2547,7 @@ impl<const BITS: u32, S: SignedInteger> CheckablePrimitive for CheckedSignedFixe
     fn read<R: BitRead + ?Sized>(
         reader: &mut R,
         count: FixedSignedBitCount<BITS>,
-    ) -> std::io::Result<Self> {
+    ) -> io::Result<Self> {
         Ok(Self {
             value: reader.read_signed::<BITS, _>()?,
             count,

--- a/src/read.rs
+++ b/src/read.rs
@@ -13,6 +13,7 @@
 #[cfg(not(feature = "std"))]
 use core2::io;
 
+#[cfg(feature = "alloc")]
 use alloc::{vec, vec::Vec};
 #[cfg(feature = "std")]
 use std::io;
@@ -683,6 +684,8 @@ pub trait BitRead {
     /// assert_eq!(r.read_to_vec(3).unwrap().as_slice(), &[0x01, 0x02, 0x03]);
     /// assert_eq!(r.read::<8, u8>().unwrap(), 0x04);
     /// ```
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn read_to_vec(&mut self, bytes: usize) -> io::Result<Vec<u8>> {
         read_to_vec(|buf| self.read_bytes(buf), bytes)
     }
@@ -1011,6 +1014,7 @@ impl<R: BitRead + ?Sized> BitRead for &mut R {
     }
 
     #[inline]
+    #[cfg(feature = "alloc")]
     fn read_to_vec(&mut self, bytes: usize) -> io::Result<Vec<u8>> {
         (**self).read_to_vec(bytes)
     }
@@ -1209,6 +1213,8 @@ pub trait BitRead2 {
     /// # Errors
     ///
     /// Passes along any I/O error from the underlying stream.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn read_to_vec(&mut self, bytes: usize) -> io::Result<Vec<u8>> {
         read_to_vec(|buf| self.read_bytes(buf), bytes)
     }
@@ -1704,8 +1710,10 @@ where
     /// assert_eq!(reader.position_in_bits().unwrap(), 6);
     /// ```
     #[inline]
+    #[allow(clippy::seek_from_current)]
     pub fn position_in_bits(&mut self) -> io::Result<u64> {
-        let bytes = self.reader.stream_position()?;
+        // core2 doesn't have `seek_from_current`
+        let bytes = self.reader.seek(io::SeekFrom::Current(0))?;
         Ok(bytes * 8 - (self.bits as u64))
     }
 }
@@ -1818,6 +1826,8 @@ pub trait ByteRead {
     /// # Errors
     ///
     /// Passes along any I/O error from the underlying stream.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn read_to_vec(&mut self, bytes: usize) -> io::Result<Vec<u8>> {
         read_to_vec(|buf| self.read_bytes(buf), bytes)
     }
@@ -2322,6 +2332,7 @@ pub trait FromByteStreamUsing {
         Self: Sized;
 }
 
+#[cfg(feature = "alloc")]
 fn read_to_vec(
     mut read: impl FnMut(&mut [u8]) -> io::Result<()>,
     bytes: usize,

--- a/src/write.rs
+++ b/src/write.rs
@@ -13,6 +13,7 @@
 #[cfg(not(feature = "std"))]
 use core2::io;
 
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::{
     convert::{From, TryFrom, TryInto},
@@ -25,6 +26,9 @@ use super::{
     BitCount, Checkable, CheckedSigned, CheckedUnsigned, Endianness, Integer, Numeric, PhantomData,
     Primitive, SignedBitCount, SignedInteger, UnsignedInteger,
 };
+
+#[cfg(feature = "alloc")]
+pub use bit_recorder::BitRecorder;
 
 /// For writing bit values to an underlying stream in a given endianness.
 ///
@@ -2122,327 +2126,337 @@ where
     }
 }
 
-/// For recording writes in order to play them back on another writer
-/// # Example
-/// ```
-/// use std::io::Write;
-/// use bitstream_io::{BigEndian, BitWriter, BitWrite, BitRecorder};
-/// let mut recorder: BitRecorder<u32, BigEndian> = BitRecorder::new();
-/// recorder.write_var(1, 0b1u8).unwrap();
-/// recorder.write_var(2, 0b01u8).unwrap();
-/// recorder.write_var(5, 0b10111u8).unwrap();
-/// assert_eq!(recorder.written(), 8);
-/// let mut writer = BitWriter::endian(Vec::new(), BigEndian);
-/// recorder.playback(&mut writer);
-/// assert_eq!(writer.into_writer(), [0b10110111]);
-/// ```
-pub struct BitRecorder<N, E: Endianness> {
-    writer: BitWriter<Vec<u8>, E>,
-    phantom: PhantomData<N>,
-}
+#[cfg(feature = "alloc")]
+mod bit_recorder {
+    use super::*;
 
-impl<N: Counter, E: Endianness> BitRecorder<N, E> {
-    /// Creates new recorder
-    #[inline]
-    pub fn new() -> Self {
-        BitRecorder {
-            writer: BitWriter::new(Vec::new()),
-            phantom: PhantomData,
-        }
-    }
-
-    /// Creates new recorder sized for the given number of bytes
-    #[inline]
-    pub fn with_capacity(bytes: usize) -> Self {
-        BitRecorder {
-            writer: BitWriter::new(Vec::with_capacity(bytes)),
-            phantom: PhantomData,
-        }
-    }
-
-    /// Creates new recorder with the given endianness
-    #[inline]
-    pub fn endian(endian: E) -> Self {
-        BitRecorder {
-            writer: BitWriter::endian(Vec::new(), endian),
-            phantom: PhantomData,
-        }
-    }
-
-    /// Returns number of bits written
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of bits written is
-    /// larger than the maximum supported by the counter type.
-    /// Use [`BitRecorder::written_checked`] for a non-panicking
-    /// alternative.
-    #[inline]
-    pub fn written(&self) -> N {
-        self.written_checked().unwrap()
-    }
-
-    /// Returns number of bits written
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the number of bits written overflows
-    /// our counter type.
-    #[inline]
-    pub fn written_checked(&self) -> Result<N, Overflowed> {
-        let mut written = N::try_from(self.writer.writer.len())
-            .map_err(|_| Overflowed)?
-            .checked_mul(8u8.into())?;
-
-        written.checked_add_assign(N::try_from(self.writer.bits).map_err(|_| Overflowed)?)?;
-
-        Ok(written)
-    }
-
-    /// Plays recorded writes to the given writer
-    #[inline]
-    pub fn playback<W: BitWrite>(&self, writer: &mut W) -> io::Result<()> {
-        writer.write_bytes(self.writer.writer.as_slice())?;
-        writer.write_var(self.writer.bits, self.writer.value)?;
-        Ok(())
-    }
-
-    /// Clears recorder, removing all values
-    #[inline]
-    pub fn clear(&mut self) {
-        self.writer = BitWriter::new({
-            let mut v = core::mem::take(&mut self.writer.writer);
-            v.clear();
-            v
-        });
-    }
-}
-
-impl<N: Counter, E: Endianness> Default for BitRecorder<N, E> {
-    #[inline]
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<N, E> BitWrite for BitRecorder<N, E>
-where
-    E: Endianness,
-    N: Counter,
-{
-    #[inline]
-    fn write_bit(&mut self, bit: bool) -> io::Result<()> {
-        BitWrite::write_bit(&mut self.writer, bit)
-    }
-
-    #[inline]
-    fn write<const BITS: u32, I>(&mut self, value: I) -> io::Result<()>
-    where
-        I: Integer,
-    {
-        BitWrite::write::<BITS, I>(&mut self.writer, value)
-    }
-
-    #[inline]
-    fn write_const<const BITS: u32, const VALUE: u32>(&mut self) -> io::Result<()> {
-        self.writer.write_const::<BITS, VALUE>()
-    }
-
-    #[inline]
-    fn write_var<I>(&mut self, bits: u32, value: I) -> io::Result<()>
-    where
-        I: Integer,
-    {
-        self.writer.write_var(bits, value)
-    }
-
-    #[inline]
-    fn write_unsigned<const BITS: u32, U>(&mut self, value: U) -> io::Result<()>
-    where
-        U: UnsignedInteger,
-    {
-        BitWrite::write_unsigned::<BITS, U>(&mut self.writer, value)
-    }
-
-    #[inline]
-    fn write_unsigned_var<U>(&mut self, bits: u32, value: U) -> io::Result<()>
-    where
-        U: UnsignedInteger,
-    {
-        self.writer.write_unsigned_var(bits, value)
-    }
-
-    #[inline]
-    fn write_signed<const BITS: u32, S>(&mut self, value: S) -> io::Result<()>
-    where
-        S: SignedInteger,
-    {
-        BitWrite::write_signed::<BITS, S>(&mut self.writer, value)
-    }
-
-    #[inline(always)]
-    fn write_signed_var<S>(&mut self, bits: u32, value: S) -> io::Result<()>
-    where
-        S: SignedInteger,
-    {
-        self.writer.write_signed_var(bits, value)
-    }
-
-    #[inline]
-    fn write_count<const MAX: u32>(&mut self, count: BitCount<MAX>) -> io::Result<()> {
-        self.writer.write_count::<MAX>(count)
-    }
-
-    #[inline]
-    fn write_counted<const MAX: u32, I>(&mut self, bits: BitCount<MAX>, value: I) -> io::Result<()>
-    where
-        I: Integer + Sized,
-    {
-        self.writer.write_counted::<MAX, I>(bits, value)
-    }
-
-    #[inline]
-    fn write_unsigned_counted<const BITS: u32, U>(
-        &mut self,
-        bits: BitCount<BITS>,
-        value: U,
-    ) -> io::Result<()>
-    where
-        U: UnsignedInteger,
-    {
-        self.writer.write_unsigned_counted::<BITS, U>(bits, value)
-    }
-
-    #[inline]
-    fn write_signed_counted<const MAX: u32, S>(
-        &mut self,
-        bits: impl TryInto<SignedBitCount<MAX>>,
-        value: S,
-    ) -> io::Result<()>
-    where
-        S: SignedInteger,
-    {
-        self.writer.write_signed_counted::<MAX, S>(bits, value)
-    }
-
-    #[inline]
-    fn write_from<V>(&mut self, value: V) -> io::Result<()>
-    where
-        V: Primitive,
-    {
-        BitWrite::write_from::<V>(&mut self.writer, value)
-    }
-
-    #[inline]
-    fn write_as_from<F, V>(&mut self, value: V) -> io::Result<()>
-    where
-        F: Endianness,
-        V: Primitive,
-    {
-        BitWrite::write_as_from::<F, V>(&mut self.writer, value)
-    }
-
-    #[inline]
-    fn pad(&mut self, bits: u32) -> io::Result<()> {
-        BitWrite::pad(&mut self.writer, bits)
-    }
-
-    #[inline]
-    fn write_bytes(&mut self, buf: &[u8]) -> io::Result<()> {
-        BitWrite::write_bytes(&mut self.writer, buf)
-    }
-
-    #[inline]
-    fn write_unary<const STOP_BIT: u8>(&mut self, value: u32) -> io::Result<()> {
-        self.writer.write_unary::<STOP_BIT>(value)
-    }
-
-    #[inline]
-    fn build<T: ToBitStream>(&mut self, build: &T) -> Result<(), T::Error> {
-        BitWrite::build(&mut self.writer, build)
-    }
-
-    #[inline]
-    fn build_with<'a, T: ToBitStreamWith<'a>>(
-        &mut self,
-        build: &T,
-        context: &T::Context,
-    ) -> Result<(), T::Error> {
-        BitWrite::build_with(&mut self.writer, build, context)
-    }
-
-    #[inline]
-    fn byte_aligned(&self) -> bool {
-        BitWrite::byte_aligned(&self.writer)
-    }
-
-    #[inline]
-    fn byte_align(&mut self) -> io::Result<()> {
-        BitWrite::byte_align(&mut self.writer)
-    }
-
-    #[inline]
-    fn write_huffman<T>(&mut self, value: T::Symbol) -> io::Result<()>
-    where
-        T: crate::huffman::ToBits,
-    {
-        BitWrite::write_huffman::<T>(&mut self.writer, value)
-    }
-}
-
-impl<N: PartialOrd + Counter + Copy, E: Endianness> BitRecorder<N, E> {
-    /// Returns shortest option between ourself and candidate
-    ///
-    /// Executes fallible closure on emptied candidate recorder,
-    /// compares the lengths of ourself and the candidate,
-    /// and returns the shorter of the two.
-    ///
-    /// If the new candidate is shorter, we swap ourself and
-    /// the candidate so any recorder capacity can be reused.
-    ///
+    /// For recording writes in order to play them back on another writer
     /// # Example
-    ///
     /// ```
-    /// use bitstream_io::{BitRecorder, BitWrite, BigEndian};
-    ///
-    /// let mut best = BitRecorder::<u8, BigEndian>::new();
-    /// let mut candidate = BitRecorder::new();
-    ///
-    /// // write an 8 bit value to our initial candidate
-    /// best.write::<8, u8>(0);
-    /// assert_eq!(best.written(), 8);
-    ///
-    /// // try another candidate which writes 4 bits
-    /// best = best.best(&mut candidate, |w| {
-    ///     w.write::<4, u8>(0)
-    /// }).unwrap();
-    ///
-    /// // which becomes our new best candidate
-    /// assert_eq!(best.written(), 4);
-    ///
-    /// // finally, try a not-so-best candidate
-    /// // which writes 10 bits
-    /// best = best.best(&mut candidate, |w| {
-    ///     w.write::<10, u16>(0)
-    /// }).unwrap();
-    ///
-    /// // so our best candidate remains 4 bits
-    /// assert_eq!(best.written(), 4);
+    /// use std::io::Write;
+    /// use bitstream_io::{BigEndian, BitWriter, BitWrite, BitRecorder};
+    /// let mut recorder: BitRecorder<u32, BigEndian> = BitRecorder::new();
+    /// recorder.write_var(1, 0b1u8).unwrap();
+    /// recorder.write_var(2, 0b01u8).unwrap();
+    /// recorder.write_var(5, 0b10111u8).unwrap();
+    /// assert_eq!(recorder.written(), 8);
+    /// let mut writer = BitWriter::endian(Vec::new(), BigEndian);
+    /// recorder.playback(&mut writer);
+    /// assert_eq!(writer.into_writer(), [0b10110111]);
     /// ```
-    pub fn best<F>(
-        mut self,
-        candidate: &mut Self,
-        f: impl FnOnce(&mut Self) -> Result<(), F>,
-    ) -> Result<Self, F> {
-        candidate.clear();
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub struct BitRecorder<N, E: Endianness> {
+        writer: BitWriter<Vec<u8>, E>,
+        phantom: PhantomData<N>,
+    }
 
-        f(candidate)?;
-
-        if candidate.written() < self.written() {
-            core::mem::swap(&mut self, candidate);
+    impl<N: Counter, E: Endianness> BitRecorder<N, E> {
+        /// Creates new recorder
+        #[inline]
+        pub fn new() -> Self {
+            BitRecorder {
+                writer: BitWriter::new(Vec::new()),
+                phantom: PhantomData,
+            }
         }
 
-        Ok(self)
+        /// Creates new recorder sized for the given number of bytes
+        #[inline]
+        pub fn with_capacity(bytes: usize) -> Self {
+            BitRecorder {
+                writer: BitWriter::new(Vec::with_capacity(bytes)),
+                phantom: PhantomData,
+            }
+        }
+
+        /// Creates new recorder with the given endianness
+        #[inline]
+        pub fn endian(endian: E) -> Self {
+            BitRecorder {
+                writer: BitWriter::endian(Vec::new(), endian),
+                phantom: PhantomData,
+            }
+        }
+
+        /// Returns number of bits written
+        ///
+        /// # Panics
+        ///
+        /// Panics if the number of bits written is
+        /// larger than the maximum supported by the counter type.
+        /// Use [`BitRecorder::written_checked`] for a non-panicking
+        /// alternative.
+        #[inline]
+        pub fn written(&self) -> N {
+            self.written_checked().unwrap()
+        }
+
+        /// Returns number of bits written
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if the number of bits written overflows
+        /// our counter type.
+        #[inline]
+        pub fn written_checked(&self) -> Result<N, Overflowed> {
+            let mut written = N::try_from(self.writer.writer.len())
+                .map_err(|_| Overflowed)?
+                .checked_mul(8u8.into())?;
+
+            written.checked_add_assign(N::try_from(self.writer.bits).map_err(|_| Overflowed)?)?;
+
+            Ok(written)
+        }
+
+        /// Plays recorded writes to the given writer
+        #[inline]
+        pub fn playback<W: BitWrite>(&self, writer: &mut W) -> io::Result<()> {
+            writer.write_bytes(self.writer.writer.as_slice())?;
+            writer.write_var(self.writer.bits, self.writer.value)?;
+            Ok(())
+        }
+
+        /// Clears recorder, removing all values
+        #[inline]
+        pub fn clear(&mut self) {
+            self.writer = BitWriter::new({
+                let mut v = core::mem::take(&mut self.writer.writer);
+                v.clear();
+                v
+            });
+        }
+    }
+
+    impl<N: Counter, E: Endianness> Default for BitRecorder<N, E> {
+        #[inline]
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl<N, E> BitWrite for BitRecorder<N, E>
+    where
+        E: Endianness,
+        N: Counter,
+    {
+        #[inline]
+        fn write_bit(&mut self, bit: bool) -> io::Result<()> {
+            BitWrite::write_bit(&mut self.writer, bit)
+        }
+
+        #[inline]
+        fn write<const BITS: u32, I>(&mut self, value: I) -> io::Result<()>
+        where
+            I: Integer,
+        {
+            BitWrite::write::<BITS, I>(&mut self.writer, value)
+        }
+
+        #[inline]
+        fn write_const<const BITS: u32, const VALUE: u32>(&mut self) -> io::Result<()> {
+            self.writer.write_const::<BITS, VALUE>()
+        }
+
+        #[inline]
+        fn write_var<I>(&mut self, bits: u32, value: I) -> io::Result<()>
+        where
+            I: Integer,
+        {
+            self.writer.write_var(bits, value)
+        }
+
+        #[inline]
+        fn write_unsigned<const BITS: u32, U>(&mut self, value: U) -> io::Result<()>
+        where
+            U: UnsignedInteger,
+        {
+            BitWrite::write_unsigned::<BITS, U>(&mut self.writer, value)
+        }
+
+        #[inline]
+        fn write_unsigned_var<U>(&mut self, bits: u32, value: U) -> io::Result<()>
+        where
+            U: UnsignedInteger,
+        {
+            self.writer.write_unsigned_var(bits, value)
+        }
+
+        #[inline]
+        fn write_signed<const BITS: u32, S>(&mut self, value: S) -> io::Result<()>
+        where
+            S: SignedInteger,
+        {
+            BitWrite::write_signed::<BITS, S>(&mut self.writer, value)
+        }
+
+        #[inline(always)]
+        fn write_signed_var<S>(&mut self, bits: u32, value: S) -> io::Result<()>
+        where
+            S: SignedInteger,
+        {
+            self.writer.write_signed_var(bits, value)
+        }
+
+        #[inline]
+        fn write_count<const MAX: u32>(&mut self, count: BitCount<MAX>) -> io::Result<()> {
+            self.writer.write_count::<MAX>(count)
+        }
+
+        #[inline]
+        fn write_counted<const MAX: u32, I>(
+            &mut self,
+            bits: BitCount<MAX>,
+            value: I,
+        ) -> io::Result<()>
+        where
+            I: Integer + Sized,
+        {
+            self.writer.write_counted::<MAX, I>(bits, value)
+        }
+
+        #[inline]
+        fn write_unsigned_counted<const BITS: u32, U>(
+            &mut self,
+            bits: BitCount<BITS>,
+            value: U,
+        ) -> io::Result<()>
+        where
+            U: UnsignedInteger,
+        {
+            self.writer.write_unsigned_counted::<BITS, U>(bits, value)
+        }
+
+        #[inline]
+        fn write_signed_counted<const MAX: u32, S>(
+            &mut self,
+            bits: impl TryInto<SignedBitCount<MAX>>,
+            value: S,
+        ) -> io::Result<()>
+        where
+            S: SignedInteger,
+        {
+            self.writer.write_signed_counted::<MAX, S>(bits, value)
+        }
+
+        #[inline]
+        fn write_from<V>(&mut self, value: V) -> io::Result<()>
+        where
+            V: Primitive,
+        {
+            BitWrite::write_from::<V>(&mut self.writer, value)
+        }
+
+        #[inline]
+        fn write_as_from<F, V>(&mut self, value: V) -> io::Result<()>
+        where
+            F: Endianness,
+            V: Primitive,
+        {
+            BitWrite::write_as_from::<F, V>(&mut self.writer, value)
+        }
+
+        #[inline]
+        fn pad(&mut self, bits: u32) -> io::Result<()> {
+            BitWrite::pad(&mut self.writer, bits)
+        }
+
+        #[inline]
+        fn write_bytes(&mut self, buf: &[u8]) -> io::Result<()> {
+            BitWrite::write_bytes(&mut self.writer, buf)
+        }
+
+        #[inline]
+        fn write_unary<const STOP_BIT: u8>(&mut self, value: u32) -> io::Result<()> {
+            self.writer.write_unary::<STOP_BIT>(value)
+        }
+
+        #[inline]
+        fn build<T: ToBitStream>(&mut self, build: &T) -> Result<(), T::Error> {
+            BitWrite::build(&mut self.writer, build)
+        }
+
+        #[inline]
+        fn build_with<'a, T: ToBitStreamWith<'a>>(
+            &mut self,
+            build: &T,
+            context: &T::Context,
+        ) -> Result<(), T::Error> {
+            BitWrite::build_with(&mut self.writer, build, context)
+        }
+
+        #[inline]
+        fn byte_aligned(&self) -> bool {
+            BitWrite::byte_aligned(&self.writer)
+        }
+
+        #[inline]
+        fn byte_align(&mut self) -> io::Result<()> {
+            BitWrite::byte_align(&mut self.writer)
+        }
+
+        #[inline]
+        fn write_huffman<T>(&mut self, value: T::Symbol) -> io::Result<()>
+        where
+            T: crate::huffman::ToBits,
+        {
+            BitWrite::write_huffman::<T>(&mut self.writer, value)
+        }
+    }
+
+    impl<N: PartialOrd + Counter + Copy, E: Endianness> BitRecorder<N, E> {
+        /// Returns shortest option between ourself and candidate
+        ///
+        /// Executes fallible closure on emptied candidate recorder,
+        /// compares the lengths of ourself and the candidate,
+        /// and returns the shorter of the two.
+        ///
+        /// If the new candidate is shorter, we swap ourself and
+        /// the candidate so any recorder capacity can be reused.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// use bitstream_io::{BitRecorder, BitWrite, BigEndian};
+        ///
+        /// let mut best = BitRecorder::<u8, BigEndian>::new();
+        /// let mut candidate = BitRecorder::new();
+        ///
+        /// // write an 8 bit value to our initial candidate
+        /// best.write::<8, u8>(0);
+        /// assert_eq!(best.written(), 8);
+        ///
+        /// // try another candidate which writes 4 bits
+        /// best = best.best(&mut candidate, |w| {
+        ///     w.write::<4, u8>(0)
+        /// }).unwrap();
+        ///
+        /// // which becomes our new best candidate
+        /// assert_eq!(best.written(), 4);
+        ///
+        /// // finally, try a not-so-best candidate
+        /// // which writes 10 bits
+        /// best = best.best(&mut candidate, |w| {
+        ///     w.write::<10, u16>(0)
+        /// }).unwrap();
+        ///
+        /// // so our best candidate remains 4 bits
+        /// assert_eq!(best.written(), 4);
+        /// ```
+        pub fn best<F>(
+            mut self,
+            candidate: &mut Self,
+            f: impl FnOnce(&mut Self) -> Result<(), F>,
+        ) -> Result<Self, F> {
+            candidate.clear();
+
+            f(candidate)?;
+
+            if candidate.written() < self.written() {
+                core::mem::swap(&mut self, candidate);
+            }
+
+            Ok(self)
+        }
     }
 }
 

--- a/tests/huffman.rs
+++ b/tests/huffman.rs
@@ -1,6 +1,3 @@
-extern crate alloc;
-extern crate bitstream_io;
-
 #[test]
 fn test_huffman_values() {
     use bitstream_io::{define_huffman_tree, BigEndian, BitRead, BitReader};

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -6,13 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate bitstream_io;
-
-#[cfg(not(feature = "std"))]
-use core2::io::{self};
-
-#[cfg(feature = "std")]
-use std::io::{self};
+use std::io;
 
 #[test]
 fn test_reader_be() {

--- a/tests/read_seek.rs
+++ b/tests/read_seek.rs
@@ -1,8 +1,4 @@
 use bitstream_io::{BigEndian, BitRead, BitReader, Endianness, LittleEndian};
-#[cfg(not(feature = "std"))]
-use core2::io::{self, Cursor, SeekFrom};
-
-#[cfg(feature = "std")]
 use std::io::{self, Cursor, SeekFrom};
 
 #[test]

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -6,8 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate bitstream_io;
-
 use bitstream_io::{
     BigEndian, BitRead, BitReader, BitWrite, BitWriter, Endianness, Integer, LittleEndian,
     Primitive,

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -6,13 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate bitstream_io;
-
 use bitstream_io::{BigEndian, BitWrite, BitWriter};
-#[cfg(not(feature = "std"))]
-use core2::io;
-
-#[cfg(feature = "std")]
 use std::io;
 
 #[test]


### PR DESCRIPTION
I have a no_alloc and no_std use-case, and it's fortunately quite a simple patch to add support for this. I have tested this patch on a target that doesn't have std, and it works like a charm.

By adding the `#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]` attribute to the few things in bitstream-io that can't function without alloc, docs-rs will automatically point out that this is only available with the alloc feature. You can also test this locally by running `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc`.

Additionally, tests now require std so you don't have to muck around with making all of the tests compatible with no_std and especially no_alloc, as per [this advice](https://users.rust-lang.org/t/is-there-any-point-in-avoiding-std-when-testing-a-no-std-library/122731/3).

This change is also forwards-compatible, so it will only require a minor version bump.

Closes #5
