### PR TITLE
Add support for encoding LLVM style variable bit rate integers

### DIFF
--- a/tests/read.rs
+++ b/tests/read.rs
@@ -110,6 +110,20 @@ fn test_reader_be() {
     assert_eq!(r.read_unary::<1>().unwrap(), 3);
     assert_eq!(r.read_unary::<1>().unwrap(), 0);
 
+    // reading unsigned vbr
+    let mut r = BitReader::endian(actual_data.as_slice(), BigEndian);
+    assert_eq!(r.read_unsigned_vbr::<4, u8>().unwrap(), 11);
+    assert_eq!(r.read_unsigned_vbr::<4, u8>().unwrap(), 238);
+    assert_eq!(r.read_unsigned_vbr::<4, u8>().unwrap(), 99);
+    assert!(r.read_unsigned_vbr::<4, u8>().is_err());
+
+    // reading signed vbr
+    let mut r = BitReader::endian(actual_data.as_slice(), BigEndian);
+    assert_eq!(r.read_signed_vbr::<4, i8>().unwrap(), -6);
+    assert_eq!(r.read_signed_vbr::<4, i8>().unwrap(), 119);
+    assert_eq!(r.read_signed_vbr::<4, i8>().unwrap(), -50);
+    assert!(r.read_signed_vbr::<4, i8>().is_err());
+
     // byte aligning
     let mut r = BitReader::endian(actual_data.as_slice(), BigEndian);
     assert_eq!(r.read_var::<u32>(3).unwrap(), 5);

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -134,6 +134,20 @@ fn test_writer_be() {
     w.write_unary::<1>(5).unwrap();
     assert_eq!(w.into_writer().as_slice(), &final_data);
 
+    // writing unsigned vbr
+    let mut w = BitWriter::endian(Vec::with_capacity(4), BigEndian);
+    w.write_unsigned_vbr::<4, _>(11u8).unwrap(); // 001 011 -> <1>011 <0>001
+    w.write_unsigned_vbr::<4, _>(238u8).unwrap(); // 011 101 110 -> <1>110 <1>101 <0>011
+    w.write_unsigned_vbr::<4, _>(99u8).unwrap(); // 001 100 011 -> <1>011 <1>100 <0>001
+    assert_eq!(w.into_writer().as_slice(), &final_data);
+
+    // writing signed vbr
+    let mut w = BitWriter::endian(Vec::with_capacity(4), BigEndian);
+    w.write_signed_vbr::<4, _>(-6i16).unwrap(); // 001 011 -> <1>011 <0>001
+    w.write_signed_vbr::<4, _>(119i16).unwrap(); // 011 101 110 -> <1>110 <1>101 <0>011
+    w.write_signed_vbr::<4, _>(-50i16).unwrap(); // 001 100 011 -> <1>011 <1>100 <0>001
+    assert_eq!(w.into_writer().as_slice(), &final_data);
+
     // byte aligning
     let aligned_data = [0xA0, 0xE0, 0x3B, 0xC0];
     let mut w = BitWriter::endian(Vec::with_capacity(4), BigEndian);


### PR DESCRIPTION
Adds methods to `BitRead` and `BitWrite` to read data encoded using a variable bit rate encoding defined [https://llvm.org/docs/BitCodeFormat.html#variable-width-integer](here)