### PR TITLE
Automatically generate feature gate docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,6 @@ pub use read::{
     BitRead, BitRead2, BitReader, ByteRead, ByteReader, FromBitStream, FromBitStreamUsing,
     FromBitStreamWith, FromByteStream, FromByteStreamUsing, FromByteStreamWith,
 };
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]
 pub use write::BitRecorder;
 pub use write::{

--- a/src/read.rs
+++ b/src/read.rs
@@ -713,7 +713,6 @@ pub trait BitRead {
     /// assert_eq!(r.read::<8, u8>().unwrap(), 0x04);
     /// ```
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn read_to_vec(&mut self, bytes: usize) -> io::Result<Vec<u8>> {
         read_to_vec(|buf| self.read_bytes(buf), bytes)
     }
@@ -1354,7 +1353,6 @@ pub trait BitRead2 {
     ///
     /// Passes along any I/O error from the underlying stream.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn read_to_vec(&mut self, bytes: usize) -> io::Result<Vec<u8>> {
         read_to_vec(|buf| self.read_bytes(buf), bytes)
     }
@@ -1967,7 +1965,6 @@ pub trait ByteRead {
     ///
     /// Passes along any I/O error from the underlying stream.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn read_to_vec(&mut self, bytes: usize) -> io::Result<Vec<u8>> {
         read_to_vec(|buf| self.read_bytes(buf), bytes)
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -2236,7 +2236,6 @@ mod bit_recorder {
     /// recorder.playback(&mut writer);
     /// assert_eq!(writer.into_writer(), [0b10110111]);
     /// ```
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub struct BitRecorder<N, E: Endianness> {
         writer: BitWriter<Vec<u8>, E>,
         phantom: PhantomData<N>,


### PR DESCRIPTION
Documentation about feature-gated members can be automatically generated with the latest changes to rust-lang/rust#43781.